### PR TITLE
Build and upload Windows libs.

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -22,3 +22,27 @@ jobs:
           path: "libsndfile.dylib"
           retention-days: 7
           if-no-files-found: error
+
+  build-libs-windows:
+    runs-on: windows-2016
+    strategy:
+      matrix:
+        include:
+        - triplet: "x64-windows-custom"
+          libname: "libsndfile_x64.dll"
+        - triplet: "x86-windows-custom"
+          libname: "libsndfile_x86.dll"
+      fail-fast: true
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build library
+        run: "vcpkg install libsndfile:${{ matrix.triplet }} --overlay-triplets=triplets"
+      - name: Copy library
+        run: "Copy-Item c:/vcpkg/installed/${{ matrix.triplet }}/bin/sndfile.dll -Destination ${{ matrix.libname }}"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: lib
+          path: ${{ matrix.libname }}
+          retention-days: 7
+          if-no-files-found: error

--- a/triplets/README.md
+++ b/triplets/README.md
@@ -1,0 +1,4 @@
+Custom triplets for Vcpkg.
+
+https://vcpkg.readthedocs.io/en/latest/users/triplets/
+https://vcpkg.readthedocs.io/en/latest/examples/overlay-triplets-linux-dynamic/

--- a/triplets/x64-windows-custom.cmake
+++ b/triplets/x64-windows-custom.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)  # Runtime always dynamically linked.
+set(VCPKG_LIBRARY_LINKAGE static)  # Libs are static by default.
+set(VCPKG_PLATFORM_TOOLSET v140)  # Enforce v140 toolset.
+set(VCPKG_BUILD_TYPE release)  # Skip debug builds.
+
+if (PORT STREQUAL libsndfile)  # Only libsndfile is dynamic.
+	set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()

--- a/triplets/x86-windows-custom.cmake
+++ b/triplets/x86-windows-custom.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE x86)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_PLATFORM_TOOLSET v140)
+set(VCPKG_BUILD_TYPE release)
+
+if (PORT STREQUAL libsndfile)
+	set(VCPKG_LIBRARY_LINKAGE dynamic)
+endif()


### PR DESCRIPTION
Combines libsndfile and its dependencies into a single dynamic library using custom Vcpkg triplets.  The built libraries are included in the lib artifact.

Uses a deprecated Windows environment.  I'm not exactly sure what to do about that other than maybe bump the toolset to `v141`.