### PR TITLE
Reuse lame flags in mpg123

### DIFF
--- a/mac_build.sh
+++ b/mac_build.sh
@@ -2,7 +2,7 @@ OGGVERSION=1.3.5
 VORBISVERSION=1.3.7
 FLACVERSION=1.3.3
 OPUSVERSION=1.3.1
-MPG123VERSION=1.29.3
+MPG123VERSION=1.30.2
 LAMEVERSION=3.100
 SNDFILE_VERSION=1.1.0
 
@@ -52,7 +52,7 @@ cd ..
 
 # mpg123
 
-curl -LO https://deac-ams.dl.sourceforge.net/project/mpg123/mpg123/$MPG123VERSION/mpg123-$MPG123VERSION.tar.bz2
+curl -LO https://sourceforge.net/projects/mpg123/files/mpg123/$MPG123VERSION/mpg123-$MPG123VERSION.tar.bz2
 tar zxvf mpg123-$MPG123VERSION.tar.bz2
 cd mpg123-$MPG123VERSION
 ./configure --enable-static --disable-shared
@@ -61,7 +61,7 @@ cd ..
 
 # liblame
 
-curl -LO https://deac-ams.dl.sourceforge.net/project/lame/lame/$LAMEVERSION/lame-$LAMEVERSION.tar.gz
+curl -LO https://sourceforge.net/projects/lame/files/lame/$LAMEVERSION/lame-$LAMEVERSION.tar.gz
 tar zxvf lame-$LAMEVERSION.tar.gz
 cd lame-$LAMEVERSION
 ./configure --enable-static --disable-shared
@@ -80,15 +80,15 @@ export VORBISENC_CFLAGS="-I$(pwd)/libvorbis-$VORBISVERSION/include"
 export VORBISENC_LIBS="$(pwd)/libvorbis-$VORBISVERSION/lib/libvorbisenc.la"
 export OPUS_CFLAGS="-I$(pwd)/opus-$OPUSVERSION/include"
 export OPUS_LIBS="$(pwd)/opus-$OPUSVERSION/libopus.la"
-export MPG123_CFLAGS="-I$(pwd)/mpg123-$MPG123VERSION/src/libmpg123/"
-export MPG123_LIBS="$(pwd)/mpg123-$MPG123VERSION/src/libmpg123/libmpg123.la"
 export LAME_CFLAGS="-I$(pwd)/lame-$LAMEVERSION/include"
 export LAME_LIBS="$(pwd)/lame-$LAMEVERSION/libmp3lame/.libs/libmp3lame.la"
+export MPG123_CFLAGS="-I$(pwd)/mpg123-$MPG123VERSION/src/libmpg123 $LAME_CFLAGS"
+export MPG123_LIBS="$(pwd)/mpg123-$MPG123VERSION/src/libmpg123/libmpg123.la $LAME_LIBS"
 
 curl -LO https://github.com/libsndfile/libsndfile/releases/download/$SNDFILE_VERSION/libsndfile-$SNDFILE_VERSION.tar.xz
 tar jxvf libsndfile-$SNDFILE_VERSION.tar.xz
 cd $SNDFILENAME
-./configure --disable-static --disable-sqlite --disable-alsa 
+./configure --disable-static --disable-sqlite --disable-alsa
 make -j$JOBS
 cd ..
 


### PR DESCRIPTION
The `LAME_CFLAGS` and `LAME_LIBS` variables don't seem to be used in the libsndfile configure script - https://github.com/libsndfile/libsndfile/blob/master/configure.ac#L437. 

We could fix it there or just fudge it here by injecting them into the MPG123 flags?
