### PR TITLE
Add riscv64 build workflow

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -100,6 +100,33 @@ jobs:
           name: lib-linux-arm64
           path: "libsndfile.so"
 
+  build-libs-linux-riscv64:
+    runs-on: ${{ matrix.os }}
+    container: debian:12
+    strategy:
+      matrix:
+        os: ["ubuntu-20.04"]
+      fail-fast: true
+
+    steps:
+      - name: Install riscv64-linux-gnu cross-compiler
+        run: |
+          apt-get update
+          apt-get install -y build-essential \
+                             curl \
+                             python3 \
+                             g++-riscv64-linux-gnu \
+                             pkg-config
+      - uses: actions/checkout@v3
+      - name: Compile library
+        run: |
+          export CONFIGURE_FLAGS="--host=riscv64-linux-gnu --build=x86_64-linux-gnu"
+          ./linux_build.sh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: lib-linux-riscv64
+          path: "libsndfile.so"
+
   build-libs-windows:
     runs-on: windows-2019
     strategy:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ is built-in statically.
 
 - DLLs for Windows (x86 32-bit and 64-bit)
 - dylib for Mac OS X (x86 64-bit and arm64)
-- so for Linux (x86 64-bit and arm64)
+- so for Linux (x86 64-bit, arm64, riscv64)
 
 Copyright
 ---------


### PR DESCRIPTION
This tweaks the Actions pipeline to include a riscv64 build variant for Linux. It also slightly modifies the README to reflect that.

With the [RISE](https://riseproject.dev/) project we are helping to build out riscv64 software + infrastructure, and more specifically building Python wheels to support some LLM/AI workflows. One of those is SGLang, which depends on [python-soundfile](https://github.com/bastibe/python-soundfile), which in turn ultimately depends on this repository, hence this PR.